### PR TITLE
geom_alt props

### DIFF
--- a/data/421/187/479/421187479.geojson
+++ b/data/421/187/479/421187479.geojson
@@ -324,6 +324,9 @@
     },
     "wof:country":"LY",
     "wof:created":1459009514,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"558e2dc259d8c4cab473fdf6284b927b",
     "wof:hierarchy":[
         {
@@ -334,7 +337,7 @@
         }
     ],
     "wof:id":421187479,
-    "wof:lastmodified":1566599274,
+    "wof:lastmodified":1582313816,
     "wof:name":"Ghadamis",
     "wof:parent_id":85673563,
     "wof:placetype":"locality",

--- a/data/421/194/651/421194651.geojson
+++ b/data/421/194/651/421194651.geojson
@@ -465,6 +465,9 @@
     },
     "wof:country":"LY",
     "wof:created":1459009815,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f2de762428d61743ab9c5bb18537f60",
     "wof:hierarchy":[
         {
@@ -475,7 +478,7 @@
         }
     ],
     "wof:id":421194651,
-    "wof:lastmodified":1566599273,
+    "wof:lastmodified":1582313816,
     "wof:name":"Tripoli",
     "wof:parent_id":85673621,
     "wof:placetype":"locality",

--- a/data/856/326/27/85632627.geojson
+++ b/data/856/326/27/85632627.geojson
@@ -1007,7 +1007,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "meso",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1082,7 +1081,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1582313815,
+    "wof:lastmodified":1583200496,
     "wof:name":"Libya",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/326/27/85632627.geojson
+++ b/data/856/326/27/85632627.geojson
@@ -1006,8 +1006,9 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "meso",
         "naturalearth",
-        "meso"
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1062,6 +1063,11 @@
     },
     "wof:country":"LY",
     "wof:country_alpha3":"LBY",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"1a9ce0de6f2496d064df5c141583dbff",
     "wof:hierarchy":[
         {
@@ -1076,7 +1082,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599228,
+    "wof:lastmodified":1582313815,
     "wof:name":"Libya",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/735/63/85673563.geojson
+++ b/data/856/735/63/85673563.geojson
@@ -327,6 +327,9 @@
         "wd:id":"Q192237"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eae3f540b51d11e7b18eff52d41cfc8d",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599228,
+    "wof:lastmodified":1582313814,
     "wof:name":"Ghadamis",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/67/85673567.geojson
+++ b/data/856/735/67/85673567.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Jufra District"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab0e73b5c0631960a62813086cd5f7a4",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599226,
+    "wof:lastmodified":1582313814,
     "wof:name":"Al Jufrah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/71/85673571.geojson
+++ b/data/856/735/71/85673571.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Kufra District"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8618302da8e9f0e8378c4d4b2e44b56a",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599228,
+    "wof:lastmodified":1582313814,
     "wof:name":"Al Kufrah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/75/85673575.geojson
+++ b/data/856/735/75/85673575.geojson
@@ -155,6 +155,9 @@
         "unlc:id":"LY-MB"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"314cacc6d6221678651f9645c5d650ba",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599227,
+    "wof:lastmodified":1582313814,
     "wof:name":"Al Marqab",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/79/85673579.geojson
+++ b/data/856/735/79/85673579.geojson
@@ -284,6 +284,9 @@
         "wd:id":"Q48232"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8ec97786c1e36e6cc43511a11a3b03b",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599228,
+    "wof:lastmodified":1582313814,
     "wof:name":"Ash Shati'",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/85/85673585.geojson
+++ b/data/856/735/85/85673585.geojson
@@ -319,6 +319,9 @@
         "wd:id":"Q48236"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cca5901f0910d6ec86017f99cac744a5",
     "wof:hierarchy":[
         {
@@ -334,7 +337,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599228,
+    "wof:lastmodified":1582313814,
     "wof:name":"Ghat",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/89/85673589.geojson
+++ b/data/856/735/89/85673589.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Murzuq District"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2fc73d9cc84945c4991ddb7022b526de",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599227,
+    "wof:lastmodified":1582313814,
     "wof:name":"Murzuq",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/93/85673593.geojson
+++ b/data/856/735/93/85673593.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Misrata District"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"213ced166c8966809aab0142a94f1a96",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599226,
+    "wof:lastmodified":1582313814,
     "wof:name":"Misratah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/97/85673597.geojson
+++ b/data/856/735/97/85673597.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Sabha District"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8dc90fc2017150f9b0fcb2a05f10410",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599227,
+    "wof:lastmodified":1582313814,
     "wof:name":"Sabha",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/05/85673605.geojson
+++ b/data/856/736/05/85673605.geojson
@@ -149,6 +149,9 @@
         "unlc:id":"LY-JI"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"854ad262100086e576ddf29258997e9f",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599224,
+    "wof:lastmodified":1582313813,
     "wof:name":"Al Jifarah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/07/85673607.geojson
+++ b/data/856/736/07/85673607.geojson
@@ -305,6 +305,9 @@
         "wk:page":"Nuqat al Khams"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"49467745280da0ffd18893ecf0931d91",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599225,
+    "wof:lastmodified":1582313813,
     "wof:name":"An Nuqat al Khams",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/11/85673611.geojson
+++ b/data/856/736/11/85673611.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Zawiya District"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d0c39294482040c97f5cb8238fb910a",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599224,
+    "wof:lastmodified":1582313813,
     "wof:name":"Az Zawiyah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/15/85673615.geojson
+++ b/data/856/736/15/85673615.geojson
@@ -211,6 +211,9 @@
         "wd:id":"Q2266662"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd2e7eb5dcc0466597be28285c768ff4",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599226,
+    "wof:lastmodified":1582313814,
     "wof:name":"Mizdah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/21/85673621.geojson
+++ b/data/856/736/21/85673621.geojson
@@ -242,6 +242,9 @@
         "wd:id":"Q32837"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c3dd25e721f8b1cc640566e5b9275e0",
     "wof:hierarchy":[
         {
@@ -257,7 +260,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599224,
+    "wof:lastmodified":1582313813,
     "wof:name":"Tajura' wa an Nawahi al Arba",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/25/85673625.geojson
+++ b/data/856/736/25/85673625.geojson
@@ -288,6 +288,9 @@
         "wd:id":"Q26023"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3953819ce454b901e9ef81d2d10f4933",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599226,
+    "wof:lastmodified":1582313814,
     "wof:name":"Al Marj",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/27/85673627.geojson
+++ b/data/856/736/27/85673627.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Jabal al Akhdar"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0cd289e2e9caa10a078eeeb5ccce9f70",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599224,
+    "wof:lastmodified":1582313813,
     "wof:name":"Al Jabal al Akhdar",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/31/85673631.geojson
+++ b/data/856/736/31/85673631.geojson
@@ -236,6 +236,9 @@
         "wd:id":"Q26000"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"619addb631a2f5cbf6047747232e4ff4",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599225,
+    "wof:lastmodified":1582313813,
     "wof:name":"Ajdabiya",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/35/85673635.geojson
+++ b/data/856/736/35/85673635.geojson
@@ -209,6 +209,9 @@
         "wk:page":"Benghazi"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66f6a9d89a25dcf2666ccf9378f1c0fe",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599223,
+    "wof:lastmodified":1582313813,
     "wof:name":"Benghazi",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/59/85673659.geojson
+++ b/data/856/736/59/85673659.geojson
@@ -240,6 +240,9 @@
         "wk:page":"Sirte District"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3ca38b11163a06e952256a132a1b8968",
     "wof:hierarchy":[
         {
@@ -255,7 +258,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599223,
+    "wof:lastmodified":1582313813,
     "wof:name":"Surt",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/63/85673663.geojson
+++ b/data/856/736/63/85673663.geojson
@@ -243,6 +243,9 @@
         "wk:page":"Derna District"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"895b36755cfb5a34f7771029fe0dc12e",
     "wof:hierarchy":[
         {
@@ -258,7 +261,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599226,
+    "wof:lastmodified":1582313814,
     "wof:name":"Al Qubbah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/65/85673665.geojson
+++ b/data/856/736/65/85673665.geojson
@@ -294,6 +294,9 @@
         "wd:id":"Q25931"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a05188079a45bb368a90847f50f80ec",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599225,
+    "wof:lastmodified":1582313813,
     "wof:name":"Al Butnan",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/69/85673669.geojson
+++ b/data/856/736/69/85673669.geojson
@@ -282,6 +282,9 @@
         "wd:id":"Q48233"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69dfbf88abadbba906ef728c87189423",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566599223,
+    "wof:lastmodified":1582313813,
     "wof:name":"Wadi al Hayaa",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/859/028/89/85902889.geojson
+++ b/data/859/028/89/85902889.geojson
@@ -81,6 +81,10 @@
         "wd:id":"Q16002330"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"cae7f9f4a69a77edbe6a120dc63e5feb",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566599222,
+    "wof:lastmodified":1582313812,
     "wof:name":"Al \u2018Ur\u016bbah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/028/91/85902891.geojson
+++ b/data/859/028/91/85902891.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":235447
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39108e3db88f37c5f4b7bcb1e5dc4673",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566599223,
+    "wof:lastmodified":1582313812,
     "wof:name":"B\u0101b \u2018Akk\u0101rah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/028/93/85902893.geojson
+++ b/data/859/028/93/85902893.geojson
@@ -148,6 +148,10 @@
         "wk:page":"Bab al-Azizia"
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"31b22598c2dd5049ef3ef5f3968092aa",
     "wof:hierarchy":[
         {
@@ -162,7 +166,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566599222,
+    "wof:lastmodified":1582313812,
     "wof:name":"B\u0101b al \u2018Az\u012bz\u012byah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/028/95/85902895.geojson
+++ b/data/859/028/95/85902895.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":892305
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1644b991f4ec6b4e0a1ce552c8736ddd",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566599222,
+    "wof:lastmodified":1582313812,
     "wof:name":"B\u00e5b Qarq\u00e5rish",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/028/97/85902897.geojson
+++ b/data/859/028/97/85902897.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":478912
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"077d2678e62fcd42267ca226cec2536d",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566599223,
+    "wof:lastmodified":1582313813,
     "wof:name":"B\u00f8 Sittah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/028/99/85902899.geojson
+++ b/data/859/028/99/85902899.geojson
@@ -74,6 +74,9 @@
         "gp:id":1352876
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e695dddb4c00c6759d9f8519cede95f6",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566599223,
+    "wof:lastmodified":1582313813,
     "wof:name":"Dak\u0101k\u012bn H\u0327am\u012bd",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/01/85902901.geojson
+++ b/data/859/029/01/85902901.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":478913
     },
     "wof:country":"LY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"315819840e56783dc081b99eca44c4a2",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566599222,
+    "wof:lastmodified":1582313812,
     "wof:name":"Qaryat al Balad\u012byah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.