### PR TITLE
Name updates

### DIFF
--- a/data/114/190/942/1/1141909421.geojson
+++ b/data/114/190/942/1/1141909421.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"13.1800117581,32.8925000194,13.1800117581,32.8925000194",
+    "geom:bbox":"13.180012,32.8925,13.180012,32.8925",
     "geom:latitude":32.8925,
     "geom:longitude":13.180012,
     "gn:country":"LY",
@@ -104,6 +104,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03c1\u03af\u03c0\u03bf\u03bb\u03b7"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Tripoli"
     ],
     "name:eng_x_preferred":[
         "Tripoli"
@@ -273,6 +276,9 @@
     "name:mon_x_preferred":[
         "\u0422\u0440\u0438\u043f\u043e\u043b\u0438"
     ],
+    "name:mri_x_preferred":[
+        "Tiripor\u012b"
+    ],
     "name:mrj_x_preferred":[
         "\u0422\u0440\u0438\u043f\u043e\u043b\u0438"
     ],
@@ -284,6 +290,9 @@
     ],
     "name:nan_x_preferred":[
         "Tripoli"
+    ],
+    "name:nds_x_preferred":[
+        "Tripolis"
     ],
     "name:nld_x_preferred":[
         "Tripoli"
@@ -462,6 +471,12 @@
     "name:yue_x_preferred":[
         "\u7684\u9ece\u6ce2\u91cc"
     ],
+    "name:zho_hk_x_preferred":[
+        "\u7684\u9ece\u6ce2\u91cc"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u7684\u9ece\u6ce2\u91cc"
+    ],
     "name:zho_x_preferred":[
         "\u7684\u9ece\u6ce2\u91cc"
     ],
@@ -586,7 +601,7 @@
     },
     "wof:country":"LY",
     "wof:created":1499131077,
-    "wof:geomhash":"f6843cc908bf9214a29f11494d1cae74",
+    "wof:geomhash":"f8f8c8c432b3dc0e125d7de28ef920df",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -596,7 +611,7 @@
         }
     ],
     "wof:id":1141909421,
-    "wof:lastmodified":1566599304,
+    "wof:lastmodified":1587428371,
     "wof:name":"Tripoli",
     "wof:parent_id":85673621,
     "wof:placetype":"locality",
@@ -610,10 +625,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.18001175807819,
-    32.89250001935369,
-    13.18001175807819,
-    32.89250001935369
+    13.180012,
+    32.8925,
+    13.180012,
+    32.8925
 ],
-  "geometry": {"coordinates":[13.18001175807819,32.89250001935369],"type":"Point"}
+  "geometry": {"coordinates":[13.180012,32.8925],"type":"Point"}
 }

--- a/data/421/199/765/421199765.geojson
+++ b/data/421/199/765/421199765.geojson
@@ -242,7 +242,13 @@
     "name:srp_x_preferred":[
         "\u0411\u0435\u043d\u0433\u0430\u0437\u0438"
     ],
+    "name:swa_x_preferred":[
+        "Benghazi"
+    ],
     "name:swe_x_preferred":[
+        "Benghazi"
+    ],
+    "name:szl_x_preferred":[
         "Benghazi"
     ],
     "name:tam_x_preferred":[
@@ -426,7 +432,7 @@
         }
     ],
     "wof:id":421199765,
-    "wof:lastmodified":1566599277,
+    "wof:lastmodified":1587428371,
     "wof:name":"\u0628\u0646\u063a\u0627\u0632\u064a",
     "wof:parent_id":85673635,
     "wof:placetype":"locality",

--- a/data/856/326/27/85632627.geojson
+++ b/data/856/326/27/85632627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":147.10162,
-    "geom:area_square_m":1617750967354.119385,
+    "geom:area_square_m":1617750968002.500732,
     "geom:bbox":"9.391466,19.5,25.149371,33.166111",
     "geom:latitude":27.044044,
     "geom:longitude":18.029402,
@@ -65,6 +65,9 @@
     "name:arg_x_preferred":[
         "Libia"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u064a\u0628\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0644\u064a\u0628\u064a\u0627"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:bam_x_variant":[
         "Libi"
+    ],
+    "name:ban_x_preferred":[
+        "Libya"
     ],
     "name:bar_x_preferred":[
         "Libyen"
@@ -212,6 +218,12 @@
     "name:ell_x_variant":[
         "\u039b\u03b9\u03b2\u03c5\u03ba\u03ae \u0391\u03c1\u03b1\u03b2\u03b9\u03ba\u03ae \u03a4\u03b6\u03b1\u03bc\u03b1\u03c7\u03b9\u03c1\u03af\u03b1"
     ],
+    "name:eng_ca_x_preferred":[
+        "Libya"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Libya"
+    ],
     "name:eng_x_historical":[
         "Great Socialist People\u2019s Libyan Arab Jamahiriya"
     ],
@@ -285,6 +297,9 @@
     ],
     "name:gag_x_preferred":[
         "Liviya"
+    ],
+    "name:gcr_x_preferred":[
+        "Libi"
     ],
     "name:gla_x_preferred":[
         "Libia"
@@ -360,6 +375,9 @@
     ],
     "name:hye_x_preferred":[
         "\u053c\u056b\u0562\u056b\u0561"
+    ],
+    "name:hyw_x_preferred":[
+        "\u053c\u056b\u057a\u056b\u0561"
     ],
     "name:ibo_x_preferred":[
         "Libya"
@@ -545,6 +563,9 @@
     "name:mon_x_preferred":[
         "\u041b\u0438\u0432\u0438"
     ],
+    "name:mri_x_preferred":[
+        "R\u012bpia"
+    ],
     "name:mrj_x_preferred":[
         "\u041b\u0438\u0432\u0438"
     ],
@@ -608,6 +629,9 @@
     "name:nov_x_preferred":[
         "Libia"
     ],
+    "name:nqo_x_preferred":[
+        "\u07df\u07cc\u07d3\u07cc\u07eb"
+    ],
     "name:nso_x_preferred":[
         "Libya"
     ],
@@ -661,6 +685,9 @@
     ],
     "name:pol_x_variant":[
         "Libijska"
+    ],
+    "name:por_br_x_preferred":[
+        "L\u00edbia"
     ],
     "name:por_x_preferred":[
         "L\u00edbia"
@@ -772,6 +799,12 @@
     "name:srd_x_preferred":[
         "L\u00ecbia"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u041b\u0438\u0431\u0438\u0458\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Libija"
+    ],
     "name:srp_x_preferred":[
         "\u041b\u0438\u0431\u0438\u0458\u0430"
     ],
@@ -792,6 +825,9 @@
     ],
     "name:szl_x_preferred":[
         "Libijo"
+    ],
+    "name:szy_x_preferred":[
+        "Libya"
     ],
     "name:tam_x_preferred":[
         "\u0bb2\u0bbf\u0baa\u0bbf\u0baf\u0bbe"
@@ -913,8 +949,17 @@
     "name:zha_x_preferred":[
         "Libya"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5229\u6bd4\u4e9a"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5229\u6bd4\u4e9e"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Libya"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5229\u6bd4\u4e9e"
     ],
     "name:zho_x_preferred":[
         "\u5229\u6bd4\u4e9a"
@@ -1082,7 +1127,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1583797382,
+    "wof:lastmodified":1587428370,
     "wof:name":"Libya",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/890/413/131/890413131.geojson
+++ b/data/890/413/131/890413131.geojson
@@ -137,7 +137,7 @@
         "\u0648\u0627\u062f\u0627\u0646 \u060c \u0644\u06cc\u0628\u06cc\u0627"
     ],
     "name:urd_x_variant":[
-        "\u0648\u0627\u062f\u0627\u0646 "
+        "\u0648\u0627\u062f\u0627\u0646"
     ],
     "name:vie_x_preferred":[
         "Waddan"
@@ -171,7 +171,7 @@
         }
     ],
     "wof:id":890413131,
-    "wof:lastmodified":1566599279,
+    "wof:lastmodified":1587163142,
     "wof:name":"Wadd\u0101n",
     "wof:parent_id":85673567,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.