### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/177/163/421177163.geojson
+++ b/data/421/177/163/421177163.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421177163,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Baydha",
     "wof:parent_id":85673627,
     "wof:placetype":"locality",

--- a/data/421/177/163/421177163.geojson
+++ b/data/421/177/163/421177163.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u064a\u0636\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Al Baydha"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421177163,
-    "wof:lastmodified":1566599277,
-    "wof:name":"\u0627\u0644\u0628\u064a\u0636\u0627",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Baydha",
     "wof:parent_id":85673627,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ly",

--- a/data/421/183/237/421183237.geojson
+++ b/data/421/183/237/421183237.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0632\u0648\u0627\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Zuwara"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421183237,
-    "wof:lastmodified":1566599278,
-    "wof:name":"\u0632\u0648\u0627\u0631\u0629",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Zuwara",
     "wof:parent_id":85673607,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ly",

--- a/data/421/183/237/421183237.geojson
+++ b/data/421/183/237/421183237.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"12.0845315,32.9355505,12.0845315,32.9355505",
+    "geom:bbox":"12.084532,32.93555,12.084532,32.93555",
     "geom:latitude":32.93555,
     "geom:longitude":12.084532,
     "iso:country":"LY",
@@ -54,7 +54,7 @@
     },
     "wof:country":"LY",
     "wof:created":1459009362,
-    "wof:geomhash":"62724fa78bec224c60a0ac9928a565f1",
+    "wof:geomhash":"87886b27297d188677e37d1a750aa9fb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421183237,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423094,
     "wof:name":"Zuwara",
     "wof:parent_id":85673607,
     "wof:placetype":"locality",
@@ -74,10 +74,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    12.0845315,
-    32.9355505,
-    12.0845315,
-    32.9355505
+    12.084532,
+    32.93555,
+    12.084532,
+    32.93555
 ],
-  "geometry": {"coordinates":[12.0845315,32.9355505],"type":"Point"}
+  "geometry": {"coordinates":[12.084532,32.93555],"type":"Point"}
 }

--- a/data/421/189/687/421189687.geojson
+++ b/data/421/189/687/421189687.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062e\u0645\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Al Khoms"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189687,
-    "wof:lastmodified":1566599275,
-    "wof:name":"\u0627\u0644\u062e\u0645\u0633",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Khoms",
     "wof:parent_id":85673575,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ly",

--- a/data/421/189/687/421189687.geojson
+++ b/data/421/189/687/421189687.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421189687,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Khoms",
     "wof:parent_id":85673575,
     "wof:placetype":"locality",

--- a/data/421/189/689/421189689.geojson
+++ b/data/421/189/689/421189689.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u063a\u0627\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Ghat"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189689,
-    "wof:lastmodified":1566599275,
-    "wof:name":"\u063a\u0627\u062a",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Ghat",
     "wof:parent_id":85673585,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ly",

--- a/data/421/189/689/421189689.geojson
+++ b/data/421/189/689/421189689.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"10.1695625,24.964359,10.1695625,24.964359",
+    "geom:bbox":"10.169562,24.964359,10.169562,24.964359",
     "geom:latitude":24.964359,
     "geom:longitude":10.169562,
     "iso:country":"LY",
@@ -54,7 +54,7 @@
     },
     "wof:country":"LY",
     "wof:created":1459009633,
-    "wof:geomhash":"16da5c21c0002e156f4a1abeb4c6c069",
+    "wof:geomhash":"cd0ed15ac9850bede58f926307f52848",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421189689,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423089,
     "wof:name":"Ghat",
     "wof:parent_id":85673585,
     "wof:placetype":"locality",
@@ -74,10 +74,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    10.1695625,
+    10.169562,
     24.964359,
-    10.1695625,
+    10.169562,
     24.964359
 ],
-  "geometry": {"coordinates":[10.1695625,24.964359],"type":"Point"}
+  "geometry": {"coordinates":[10.169562,24.964359],"type":"Point"}
 }

--- a/data/421/189/693/421189693.geojson
+++ b/data/421/189/693/421189693.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421189693,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423091,
     "wof:name":"Murzuk",
     "wof:parent_id":85673589,
     "wof:placetype":"locality",

--- a/data/421/189/693/421189693.geojson
+++ b/data/421/189/693/421189693.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0631\u0632\u0642"
+    ],
+    "name:eng_x_preferred":[
+        "Murzuk"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189693,
-    "wof:lastmodified":1566599275,
-    "wof:name":"\u0645\u0631\u0632\u0642",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Murzuk",
     "wof:parent_id":85673589,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ly",

--- a/data/421/189/701/421189701.geojson
+++ b/data/421/189/701/421189701.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0637\u0628\u0631\u0642"
+    ],
+    "name:eng_x_preferred":[
+        "Tobruk"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189701,
-    "wof:lastmodified":1566599274,
-    "wof:name":"\u0637\u0628\u0631\u0642",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Tobruk",
     "wof:parent_id":85673665,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ly",

--- a/data/421/189/701/421189701.geojson
+++ b/data/421/189/701/421189701.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421189701,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tobruk",
     "wof:parent_id":85673665,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.