### PR TITLE
wf concordances, placetype local, and more

### DIFF
--- a/data/856/326/27/85632627.geojson
+++ b/data/856/326/27/85632627.geojson
@@ -1245,6 +1245,7 @@
         "hasc:id":"LY",
         "icao:code":"5A",
         "ioc:id":"LBA",
+        "iso:code":"LY",
         "itu:id":"LBY",
         "loc:id":"n79066419",
         "m49:code":"434",
@@ -1259,6 +1260,7 @@
         "wk:page":"Libya",
         "wmo:id":"LY"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:country_alpha3":"LBY",
     "wof:geom_alt":[
@@ -1280,7 +1282,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639499,
+    "wof:lastmodified":1695881153,
     "wof:name":"Libya",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/326/27/85632627.geojson
+++ b/data/856/326/27/85632627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":147.10162,
-    "geom:area_square_m":1617750968002.500732,
+    "geom:area_square_m":1617750968002.504639,
     "geom:bbox":"9.391466,19.5,25.149371,33.166111",
     "geom:latitude":27.044044,
     "geom:longitude":18.029402,
@@ -14,6 +14,9 @@
     "iso:country":"LY",
     "itu:country_code":[
         "218"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "country"
     ],
     "label:eng_x_preferred_shortcode":[
         "LY"
@@ -1203,7 +1206,8 @@
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"wk",
+    "src:population":"naturalearth",
+    "src:population_year":"2019",
     "statoids:dial":"218",
     "statoids:ds":"LAR",
     "statoids:fifa":"LBY",
@@ -1262,7 +1266,7 @@
         "naturalearth-display-terrestrial-zoom6",
         "naturalearth"
     ],
-    "wof:geomhash":"925ebed499a9b809a1d65032aed43a25",
+    "wof:geomhash":"d4acd30fa8ef355ccbe0f920b43a1974",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -1276,12 +1280,12 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938880,
+    "wof:lastmodified":1694492044,
     "wof:name":"Libya",
     "wof:parent_id":102191573,
     "wof:placetype":"country",
-    "wof:population":6201521,
-    "wof:population_rank":13,
+    "wof:population":6777452,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ly",
     "wof:shortcode":"LY",
     "wof:superseded_by":[],

--- a/data/856/326/27/85632627.geojson
+++ b/data/856/326/27/85632627.geojson
@@ -1207,7 +1207,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"naturalearth",
-    "src:population_year":"2019",
+    "src:population_date":"2019",
     "statoids:dial":"218",
     "statoids:ds":"LAR",
     "statoids:fifa":"LBY",
@@ -1280,7 +1280,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694492044,
+    "wof:lastmodified":1694639499,
     "wof:name":"Libya",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/735/63/85673563.geojson
+++ b/data/856/735/63/85673563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.090157,
-    "geom:area_square_m":64971690872.801567,
+    "geom:area_square_m":64971699819.454414,
     "geom:bbox":"9.391603,28.840822,11.946718,32.354003",
     "geom:latitude":30.358659,
     "geom:longitude":10.918584,
@@ -358,15 +358,17 @@
         "gn:id":2214432,
         "gp:id":2346139,
         "hasc:id":"LY.NT",
+        "iso:code":"LY-NL",
         "iso:id":"LY-NL",
         "qs_pg:id":1115652,
         "wd:id":"Q192237"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dc0de358bff2c5b0826165b449201854",
+    "wof:geomhash":"76164f27de4bc17db2428dec992f4912",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -381,7 +383,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938878,
+    "wof:lastmodified":1695884777,
     "wof:name":"Ghadamis",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/67/85673567.geojson
+++ b/data/856/735/67/85673567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.631467,
-    "geom:area_square_m":116134060184.300903,
+    "geom:area_square_m":116134069886.761612,
     "geom:bbox":"14.313815,26.003809,19.172235,29.970843",
     "geom:latitude":27.928395,
     "geom:longitude":17.084965,
@@ -298,17 +298,19 @@
         "gn:id":2219944,
         "gp:id":2346122,
         "hasc:id":"LY.JF",
+        "iso:code":"LY-JU",
         "iso:id":"LY-JU",
         "qs_pg:id":894919,
         "unlc:id":"LY-JU",
         "wd:id":"Q48247",
         "wk:page":"Jufra District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5eb0039c3bb1983091976261e411abc2",
+    "wof:geomhash":"663cc60e0f4e8f7cea45561e7fe15632",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938877,
+    "wof:lastmodified":1695884777,
     "wof:name":"Al Jufrah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/71/85673571.geojson
+++ b/data/856/735/71/85673571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":37.215663,
-    "geom:area_square_m":420856128281.922424,
+    "geom:area_square_m":420856121847.295959,
     "geom:bbox":"19.168097,19.508045,25.0,27.049711",
     "geom:latitude":23.786703,
     "geom:longitude":22.267571,
@@ -309,17 +309,19 @@
         "gn:id":88932,
         "gp:id":2346123,
         "hasc:id":"LY.KU",
+        "iso:code":"LY-KF",
         "iso:id":"LY-KF",
         "qs_pg:id":894920,
         "unlc:id":"LY-KF",
         "wd:id":"Q48200",
         "wk:page":"Kufra District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7c1b28e146ce38fba405da3fa31bc5b3",
+    "wof:geomhash":"87015facc4ed483cf06978d0a7b263b5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -334,7 +336,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938879,
+    "wof:lastmodified":1695884331,
     "wof:name":"Al Kufrah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/75/85673575.geojson
+++ b/data/856/735/75/85673575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.651564,
-    "geom:area_square_m":6802109164.080935,
+    "geom:area_square_m":6802109001.670697,
     "geom:bbox":"13.275869,32.009993,14.448547,32.802082",
     "geom:latitude":32.404879,
     "geom:longitude":13.832671,
@@ -156,15 +156,17 @@
         "gn:id":7602691,
         "gp:id":2346133,
         "hasc:id":"LY.MR",
+        "iso:code":"LY-MB",
         "iso:id":"LY-MB",
         "qs_pg:id":1115651,
         "unlc:id":"LY-MB"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4398c008f595bc0a5b5c0c6bd348ce9b",
+    "wof:geomhash":"7b5e81c42de64428175da4b9400b6ff3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -179,7 +181,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636494815,
+    "wof:lastmodified":1695884777,
     "wof:name":"Al Marqab",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/79/85673579.geojson
+++ b/data/856/735/79/85673579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.322173,
-    "geom:area_square_m":101790867791.749756,
+    "geom:area_square_m":101790856340.808411,
     "geom:bbox":"9.837124,26.217514,15.894074,28.969825",
     "geom:latitude":27.98102,
     "geom:longitude":12.582136,
@@ -300,15 +300,17 @@
         "gn:id":2219413,
         "gp:id":2346124,
         "hasc:id":"LY.WS",
+        "iso:code":"LY-WS",
         "iso:id":"LY-WS",
         "qs_pg:id":1195768,
         "wd:id":"Q48232"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9268a02856d0f4c3badf8f5083abb57f",
+    "wof:geomhash":"f2a26ac4538722c481e113d916785004",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938878,
+    "wof:lastmodified":1695884777,
     "wof:name":"Ash Shati'",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/85/85673585.geojson
+++ b/data/856/735/85/85673585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.527014,
-    "geom:area_square_m":50279050852.408104,
+    "geom:area_square_m":50279052734.846466,
     "geom:bbox":"9.400672,24.200785,11.48099,27.847058",
     "geom:latitude":26.063543,
     "geom:longitude":10.569554,
@@ -320,16 +320,18 @@
         "gn:id":2217350,
         "gp:id":2346135,
         "hasc:id":"LY.GH",
+        "iso:code":"LY-GT",
         "iso:id":"LY-GT",
         "qs_pg:id":560789,
         "unlc:id":"LY-GT",
         "wd:id":"Q48236"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"14cbd2e9af6ba4719867a3aca21b5b43",
+    "wof:geomhash":"ba1330499d42f3b7cc909f2694261af8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -344,7 +346,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938879,
+    "wof:lastmodified":1695884777,
     "wof:name":"Ghat",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/89/85673589.geojson
+++ b/data/856/735/89/85673589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":25.012194,
-    "geom:area_square_m":281087081843.339478,
+    "geom:area_square_m":281087068090.678162,
     "geom:bbox":"11.332641,21.970348,19.185823,27.075228",
     "geom:latitude":24.63373,
     "geom:longitude":15.679414,
@@ -296,17 +296,19 @@
         "gn:id":2214602,
         "gp:id":2346125,
         "hasc:id":"LY.MU",
+        "iso:code":"LY-MQ",
         "iso:id":"LY-MQ",
         "qs_pg:id":235606,
         "unlc:id":"LY-MQ",
         "wd:id":"Q48239",
         "wk:page":"Murzuq District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d4e7117a8d1f4251a22ee14f03aa52cd",
+    "wof:geomhash":"d2b6f194c95a5a3e1cde56bb41e0dfc5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938878,
+    "wof:lastmodified":1695884777,
     "wof:name":"Murzuq",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/93/85673593.geojson
+++ b/data/856/735/93/85673593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.774128,
-    "geom:area_square_m":29230305831.581017,
+    "geom:area_square_m":29230304155.614994,
     "geom:bbox":"13.305799,30.391297,15.679864,32.530019",
     "geom:latitude":31.555394,
     "geom:longitude":14.435856,
@@ -296,17 +296,19 @@
         "gn:id":2214845,
         "gp:id":2346141,
         "hasc:id":"LY.MS",
+        "iso:code":"LY-MI",
         "iso:id":"LY-MI",
         "qs_pg:id":1135143,
         "unlc:id":"LY-MI",
         "wd:id":"Q32845",
         "wk:page":"Misrata District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e21dd2de5b57f0a0c89688d067422f21",
+    "wof:geomhash":"de868cd763e782966e5a6abd0b1c1aba",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938877,
+    "wof:lastmodified":1695884777,
     "wof:name":"Misratah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/735/97/85673597.geojson
+++ b/data/856/735/97/85673597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.56802,
-    "geom:area_square_m":17262633326.534069,
+    "geom:area_square_m":17262633357.128525,
     "geom:bbox":"13.932375,26.245073,16.280724,27.741194",
     "geom:latitude":27.082667,
     "geom:longitude":15.018228,
@@ -284,17 +284,19 @@
         "gn:id":2212774,
         "gp:id":2346126,
         "hasc:id":"LY.SA",
+        "iso:code":"LY-SB",
         "iso:id":"LY-SB",
         "qs_pg:id":235607,
         "unlc:id":"LY-SB",
         "wd:id":"Q26132",
         "wk:page":"Sabha District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3d1aa343db48c25c0c4de7d850ebfe59",
+    "wof:geomhash":"57480893ed444c8f6bb33c2984e86e42",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938878,
+    "wof:lastmodified":1695884778,
     "wof:name":"Sabha",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/05/85673605.geojson
+++ b/data/856/736/05/85673605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25597,
-    "geom:area_square_m":2667833400.138626,
+    "geom:area_square_m":2667833745.986401,
     "geom:bbox":"12.767896,32.259462,13.373516,32.857126",
     "geom:latitude":32.553578,
     "geom:longitude":13.076339,
@@ -151,15 +151,17 @@
         "gn:id":7602690,
         "gp:id":2346121,
         "hasc:id":"LY.JR",
+        "iso:code":"LY-JI",
         "iso:id":"LY-JI",
         "qs_pg:id":215762,
         "unlc:id":"LY-JI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"978d58d0be5f92af918603f83224d536",
+    "wof:geomhash":"2efab7a23a203c0e73967b416c61a9cc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -174,7 +176,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636494813,
+    "wof:lastmodified":1695884776,
     "wof:name":"Al Jifarah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/07/85673607.geojson
+++ b/data/856/736/07/85673607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.581466,
-    "geom:area_square_m":6051987837.81855,
+    "geom:area_square_m":6051988551.753676,
     "geom:bbox":"11.425398,32.267976,12.55444,33.164505",
     "geom:latitude":32.676266,
     "geom:longitude":11.901305,
@@ -308,17 +308,19 @@
         "gn:id":2593778,
         "gp:id":2346134,
         "hasc:id":"LY.NK",
+        "iso:code":"LY-NQ",
         "iso:id":"LY-NQ",
         "qs_pg:id":894918,
         "unlc:id":"LY-NQ",
         "wd:id":"Q26161",
         "wk:page":"Nuqat al Khams"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c9127962b758540d5b99e65177deeb43",
+    "wof:geomhash":"f2602369975fec618c9aa6fc95b4d1c2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938875,
+    "wof:lastmodified":1695884777,
     "wof:name":"An Nuqat al Khams",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/11/85673611.geojson
+++ b/data/856/736/11/85673611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.264075,
-    "geom:area_square_m":2754781802.429067,
+    "geom:area_square_m":2754781687.907242,
     "geom:bbox":"12.085951,32.192099,12.835081,32.800368",
     "geom:latitude":32.473223,
     "geom:longitude":12.543744,
@@ -284,17 +284,19 @@
         "gn:id":2218972,
         "gp:id":2346136,
         "hasc:id":"LY.ZW",
+        "iso:code":"LY-ZA",
         "iso:id":"LY-ZA",
         "qs_pg:id":1083842,
         "unlc:id":"LY-ZA",
         "wd:id":"Q26153",
         "wk:page":"Zawiya District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eefbbe1fe3e73c54080e5fc43ce0a0fa",
+    "wof:geomhash":"a7d3578bd2a30e3a846aac64be00b45d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938875,
+    "wof:lastmodified":1695884776,
     "wof:name":"Az Zawiyah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/15/85673615.geojson
+++ b/data/856/736/15/85673615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.204466,
-    "geom:area_square_m":76790865640.107864,
+    "geom:area_square_m":76790858030.551041,
     "geom:bbox":"11.705479,28.965173,14.7413,32.413318",
     "geom:latitude":30.444816,
     "geom:longitude":13.021001,
@@ -245,15 +245,17 @@
         "gn:id":7602689,
         "gp:id":2346140,
         "hasc:id":"LY.JG",
+        "iso:code":"LY-JG",
         "iso:id":"LY-JG",
         "qs_pg:id":232416,
         "wd:id":"Q2266662"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e0ba89143097d335dc2c0f47a523991",
+    "wof:geomhash":"30c21d046a437a46265a0bf3ccf38b34",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -268,7 +270,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938877,
+    "wof:lastmodified":1695884777,
     "wof:name":"Mizdah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/21/85673621.geojson
+++ b/data/856/736/21/85673621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080422,
-    "geom:area_square_m":835990346.477144,
+    "geom:area_square_m":835989989.744004,
     "geom:bbox":"13.065496,32.625308,13.598265,32.911251",
     "geom:latitude":32.788988,
     "geom:longitude":13.338001,
@@ -249,15 +249,17 @@
         "gn:id":2210245,
         "gp:id":2346144,
         "hasc:id":"LY.TR",
+        "iso:code":"LY-TB",
         "iso:id":"LY-TB",
         "qs_pg:id":1115653,
         "wd:id":"Q32837"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"38a255963161d5ac956669fb52707e6d",
+    "wof:geomhash":"15d5ee34d021881a4ab928d76abbbacf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -272,7 +274,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636494813,
+    "wof:lastmodified":1695884776,
     "wof:name":"Tajura' wa an Nawahi al Arba",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/25/85673625.geojson
+++ b/data/856/736/25/85673625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.032306,
-    "geom:area_square_m":10826711598.084972,
+    "geom:area_square_m":10826711022.090874,
     "geom:bbox":"20.578398,31.032841,21.717186,32.780606",
     "geom:latitude":31.983062,
     "geom:longitude":21.223851,
@@ -288,16 +288,18 @@
         "gn:id":88904,
         "gp:id":2346131,
         "hasc:id":"LY.MA",
+        "iso:code":"LY-MJ",
         "iso:id":"LY-MJ",
         "qs_pg:id":1135142,
         "unlc:id":"LY-MJ",
         "wd:id":"Q26023"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2db0d2c8ede674537cd98a6a2a491a52",
+    "wof:geomhash":"a42ff2f0f6cd010fc697ebdb3f9b7a43",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938877,
+    "wof:lastmodified":1695884777,
     "wof:name":"Al Marj",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/27/85673627.geojson
+++ b/data/856/736/27/85673627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.800916,
-    "geom:area_square_m":8386295227.174059,
+    "geom:area_square_m":8386292826.971913,
     "geom:bbox":"21.331921,31.065676,22.112522,32.938591",
     "geom:latitude":32.131151,
     "geom:longitude":21.74945,
@@ -294,16 +294,18 @@
         "gn:id":443289,
         "gp:id":2346132,
         "hasc:id":"LY.JK",
+        "iso:code":"LY-JA",
         "iso:id":"LY-JA",
         "qs_pg:id":235608,
         "wd:id":"Q32841",
         "wk:page":"Jabal al Akhdar"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3a9f54287f2fe0cb8f88fbd1fdc390fd",
+    "wof:geomhash":"7dd619fc674f87fef233310613b52d3a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938875,
+    "wof:lastmodified":1695884776,
     "wof:name":"Al Jabal al Akhdar",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/31/85673631.geojson
+++ b/data/856/736/31/85673631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":18.253002,
-    "geom:area_square_m":197707913144.270081,
+    "geom:area_square_m":197707928253.280914,
     "geom:bbox":"18.499294,27.007671,24.999997,31.262869",
     "geom:latitude":28.819307,
     "geom:longitude":21.356011,
@@ -240,15 +240,17 @@
         "gn:id":7602692,
         "gp:id":2346130,
         "hasc:id":"LY.AW",
+        "iso:code":"LY-WA",
         "iso:id":"LY-WA",
         "qs_pg:id":1135141,
         "wd:id":"Q26000"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"caa919e34a877441f5b569ba3ba7f6da",
+    "wof:geomhash":"684f51f5a60095a02f0c8b6341c885db",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -263,7 +265,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938876,
+    "wof:lastmodified":1695884777,
     "wof:name":"Ajdabiya",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/35/85673635.geojson
+++ b/data/856/736/35/85673635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.287928,
-    "geom:area_square_m":13556154196.255781,
+    "geom:area_square_m":13556158104.729471,
     "geom:bbox":"19.924092,31.007036,21.319094,32.547588",
     "geom:latitude":31.652865,
     "geom:longitude":20.569509,
@@ -203,17 +203,19 @@
         "gn:id":88318,
         "gp:id":2346137,
         "hasc:id":"LY.BG",
+        "iso:code":"LY-BA",
         "iso:id":"LY-BA",
         "qs_pg:id":1083843,
         "unlc:id":"LY-BA",
         "wd:id":"Q33507",
         "wk:page":"Benghazi"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"474686ea2bea1130aaef268bdd5b9560",
+    "wof:geomhash":"fc2cbda974d40895b7249a8fc075b8a1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -228,7 +230,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938874,
+    "wof:lastmodified":1695884520,
     "wof:name":"Benghazi",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/59/85673659.geojson
+++ b/data/856/736/59/85673659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.069583,
-    "geom:area_square_m":75551974479.014542,
+    "geom:area_square_m":75551976072.169922,
     "geom:bbox":"14.562795,28.484673,18.791243,31.436194",
     "geom:latitude":30.195165,
     "geom:longitude":16.75223,
@@ -263,17 +263,19 @@
         "gn:id":2210553,
         "gp:id":2346143,
         "hasc:id":"LY.ST",
+        "iso:code":"LY-SR",
         "iso:id":"LY-SR",
         "qs_pg:id":1175818,
         "unlc:id":"LY-SR",
         "wd:id":"Q26417",
         "wk:page":"Sirte District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2487b945053365b110a889ee15853673",
+    "wof:geomhash":"ef4eec1dfac1ad51d90e93fe494e7127",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -288,7 +290,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938874,
+    "wof:lastmodified":1695884776,
     "wof:name":"Surt",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/63/85673663.geojson
+++ b/data/856/736/63/85673663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.015415,
-    "geom:area_square_m":21156166918.270657,
+    "geom:area_square_m":21156169231.57933,
     "geom:bbox":"21.917751,30.79162,23.287889,32.933762",
     "geom:latitude":31.900998,
     "geom:longitude":22.542924,
@@ -252,17 +252,19 @@
         "gn:id":87204,
         "gp:id":2346138,
         "hasc:id":"LY.DA",
+        "iso:code":"LY-DR",
         "iso:id":"LY-DR",
         "qs_pg:id":1083844,
         "unlc:id":"LY-DR",
         "wd:id":"Q26124",
         "wk:page":"Derna District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"436f4d8cd11694e563a0e8c9ede2b233",
+    "wof:geomhash":"bbaddf90dc24ae2dea79cd3d1b065066",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -277,7 +279,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938876,
+    "wof:lastmodified":1695884777,
     "wof:name":"Al Qubbah",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/65/85673665.geojson
+++ b/data/856/736/65/85673665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.461933,
-    "geom:area_square_m":79811796152.370728,
+    "geom:area_square_m":79811794406.691864,
     "geom:bbox":"22.955601,28.093219,25.149304,32.236296",
     "geom:latitude":30.097889,
     "geom:longitude":23.990733,
@@ -294,16 +294,18 @@
         "gn:id":7602688,
         "gp:id":2346128,
         "hasc:id":"LY.BN",
+        "iso:code":"LY-BU",
         "iso:id":"LY-BU",
         "qs_pg:id":1135140,
         "unlc:id":"LY-BU",
         "wd:id":"Q25931"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"31a85a1407cd9660ad098dc87d124f2f",
+    "wof:geomhash":"e56af07eb3fca339e5dee9cc5a998be7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938876,
+    "wof:lastmodified":1695884777,
     "wof:name":"Al Butnan",
     "wof:parent_id":85632627,
     "wof:placetype":"region",

--- a/data/856/736/69/85673669.geojson
+++ b/data/856/736/69/85673669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.931574,
-    "geom:area_square_m":32469386525.223213,
+    "geom:area_square_m":32469395227.791668,
     "geom:bbox":"11.29049,25.54784,14.146296,27.292233",
     "geom:latitude":26.394895,
     "geom:longitude":12.752466,
@@ -287,14 +287,16 @@
         "gn:id":7602693,
         "gp:id":-2346135,
         "hasc:id":"LY.WH",
+        "iso:code":"LY-WD",
         "iso:id":"LY-WD",
         "wd:id":"Q48233"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"60ea4b6015f0197f5e42df34a59e8919",
+    "wof:geomhash":"f2aad4fe44e204566ae537971449dcd9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938874,
+    "wof:lastmodified":1695884777,
     "wof:name":"Wadi al Hayaa",
     "wof:parent_id":85632627,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.